### PR TITLE
Harden proxy trust and header handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     verikloak-bff (0.1.0)
-      jwt (~> 2.7)
+      jwt (>= 2.7, < 4.0)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.1.2, < 0.2)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See `examples/rack.ru` for a tiny Rack app demo.
 
 | Key                          | Type                                 | Default      | Description |
 |----------------------------- |--------------------------------------|--------------|-------------|
-| `trusted_proxies`            | Array[String/Regexp/Proc]            | `[]`         | Allowlist for proxy peers (by IP/CIDR/regex/proc). |
+| `trusted_proxies`            | Array[String/Regexp/Proc]            | *(required)* | Allowlist for proxy peers (by IP/CIDR/regex/proc). |
 | `prefer_forwarded`           | Boolean                              | `true`       | Prefer `X-Forwarded-Access-Token` over `Authorization`. |
 | `require_forwarded_header`   | Boolean                              | `false`      | Reject when no `X-Forwarded-Access-Token` (blocks direct access). |
 | `enforce_header_consistency` | Boolean                              | `true`       | If both headers exist, require identical token values. |
@@ -52,7 +52,7 @@ See `examples/rack.ru` for a tiny Rack app demo.
 | `peer_preference`            | Symbol (`:remote_then_xff`/`:xff_only`) | `:remote_then_xff` | Whether to prefer `REMOTE_ADDR` before falling back to XFF. |
 | `clock_skew_leeway`          | Integer (seconds)                    | `30`         | Reserved for small exp/nbf skew handled by core verifier. |
 | `logger`                     | `Logger` or `nil`                    | `nil`        | Logger for audit tags (`rid`, `sub`, `kid`, `iss/aud`). |
-| `token_header_priority`      | Array[String]                        | see code     | When Authorization is empty and no token chosen, seed it from these env headers in order. `HTTP_AUTHORIZATION` is ignored as a source; forwarded header is considered only from trusted peers. |
+| `token_header_priority`      | Array[String]                        | `['HTTP_X_FORWARDED_ACCESS_TOKEN']` | When Authorization is empty and no token chosen, seed it from these env headers in order. `HTTP_AUTHORIZATION` is ignored as a source; forwarded header is considered only from trusted peers. |
 | `forwarded_header_name`      | String                               | `HTTP_X_FORWARDED_ACCESS_TOKEN` | Env key for forwarded access token. |
 | `auth_request_headers`       | Hash                                 | see code     | Mapping for `X-Auth-Request-*` env keys: `{ email, user, groups }`. |
 

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -55,6 +55,8 @@ Verikloak::BFF.configure do |c|
 end
 ```
 
+`trusted_proxies` must not be left empty; the middleware raises an error when no allowlist is provided.
+
 ## 3) Reverse proxy examples
 
 Nginx auth_request:

--- a/lib/verikloak/bff/configuration.rb
+++ b/lib/verikloak/bff/configuration.rb
@@ -53,10 +53,9 @@ module Verikloak
           groups: 'HTTP_X_AUTH_REQUEST_GROUPS'
         }
         # When Authorization is empty and no chosen token exists, try these env headers (in order)
-        # to seed Authorization, similar to verikloak-rails behavior. HTTP_AUTHORIZATION is ignored as a source.
+        # to seed Authorization, similar to verikloak-rails behavior. HTTP_AUTHORIZATION is always ignored as a source.
         @token_header_priority = %w[
           HTTP_X_FORWARDED_ACCESS_TOKEN
-          HTTP_AUTHORIZATION
         ]
       end
     end

--- a/lib/verikloak/bff/consistency_checks.rb
+++ b/lib/verikloak/bff/consistency_checks.rb
@@ -7,6 +7,7 @@
 
 require 'json'
 require 'jwt' # used only to parse segments safely without verify
+require 'verikloak/bff/constants'
 
 module Verikloak
   module BFF
@@ -19,11 +20,10 @@ module Verikloak
       #
       # @param token [String, nil]
       # @return [Hash] claims or empty hash on error
-      MAX_TOKEN_BYTES = 4096
 
       def decode_claims(token)
         return {} unless token
-        return {} if token.bytesize > MAX_TOKEN_BYTES
+        return {} if token.bytesize > Constants::MAX_TOKEN_BYTES
 
         JWT.decode(token, nil, false).first
       rescue StandardError

--- a/lib/verikloak/bff/consistency_checks.rb
+++ b/lib/verikloak/bff/consistency_checks.rb
@@ -19,14 +19,13 @@ module Verikloak
       #
       # @param token [String, nil]
       # @return [Hash] claims or empty hash on error
+      MAX_TOKEN_BYTES = 4096
+
       def decode_claims(token)
         return {} unless token
+        return {} if token.bytesize > MAX_TOKEN_BYTES
 
-        parts = token.split('.')
-        return {} unless parts.size >= 2
-
-        payload = JWT::Base64.url_decode(parts[1])
-        JSON.parse(payload)
+        JWT.decode(token, nil, false).first
       rescue StandardError
         {}
       end

--- a/lib/verikloak/bff/constants.rb
+++ b/lib/verikloak/bff/constants.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Verikloak
+  module BFF
+    module Constants
+      MAX_TOKEN_BYTES = 4096
+    end
+  end
+end

--- a/lib/verikloak/bff/forwarded_token.rb
+++ b/lib/verikloak/bff/forwarded_token.rb
@@ -57,7 +57,7 @@ module Verikloak
       # @param token [String]
       # @return [String]
       def ensure_bearer(token)
-        s = token.to_s.strip
+        s = sanitize(token)
         # Case-insensitive 'Bearer' with spaces/tabs after
         if s =~ /\ABearer[ \t]+/i
           rest = s.sub(/\ABearer[ \t]+/i, '')
@@ -84,6 +84,14 @@ module Verikloak
         return unless existing.empty? || normalize_auth(existing).nil?
 
         env[AUTH_HEADER] = ensure_bearer(token)
+      end
+
+      # Remove CRLF and other control characters to prevent header injection.
+      #
+      # @param token [String]
+      # @return [String]
+      def sanitize(token)
+        token.to_s.gsub(/[[:cntrl:]]/, '').strip
       end
 
       # Remove potentially forged X-Auth-Request-* headers before passing

--- a/lib/verikloak/bff/forwarded_token.rb
+++ b/lib/verikloak/bff/forwarded_token.rb
@@ -45,7 +45,7 @@ module Verikloak
         return nil unless raw
 
         token = raw.to_s.strip
-        return ::Regexp.last_match(1) if token =~ /^Bearer\s+(.+)$/i
+        token = token.sub(/^Bearer\s+/i, '') if token =~ /^Bearer\s+/i
 
         token.empty? ? nil : token
       end

--- a/lib/verikloak/bff/header_guard.rb
+++ b/lib/verikloak/bff/header_guard.rb
@@ -14,6 +14,7 @@ require 'rack'
 require 'rack/utils'
 require 'json'
 require 'jwt'
+require 'digest'
 require 'verikloak/bff/configuration'
 require 'verikloak/bff/errors'
 require 'verikloak/bff/proxy_trust'
@@ -201,7 +202,9 @@ module Verikloak
       def enforce_header_consistency!(env, auth_token, fwd_token)
         return unless @config.enforce_header_consistency
         return unless auth_token && fwd_token
-        return if Rack::Utils.secure_compare(auth_token, fwd_token)
+        digest_a = ::Digest::SHA256.hexdigest(auth_token)
+        digest_b = ::Digest::SHA256.hexdigest(fwd_token)
+        return if Rack::Utils.secure_compare(digest_a, digest_b)
 
         log_event(env, :mismatch, reason: 'authorization_vs_forwarded')
         raise HeaderMismatchError

--- a/lib/verikloak/bff/proxy_trust.rb
+++ b/lib/verikloak/bff/proxy_trust.rb
@@ -23,7 +23,7 @@ module Verikloak
       # @example CIDR + Regex allowlist
       #   ProxyTrust.trusted?(env, ["10.0.0.0/8", /^192\.168\./], :rightmost)
       def trusted?(env, trusted, strategy = :rightmost)
-        return true if trusted.nil? || trusted.empty?
+        return false if trusted.nil? || trusted.empty?
 
         # Rails-aligned: prefer REMOTE_ADDR; fallback to nearest XFF entry
         remote = (env['REMOTE_ADDR'] || '').to_s.strip
@@ -108,7 +108,7 @@ module Verikloak
       # @param trusted [Array<String, Regexp, Proc>, nil]
       # @return [Boolean]
       def self.from_trusted_proxy?(env, trusted)
-        return true if trusted.nil? || trusted.empty?
+        return false if trusted.nil? || trusted.empty?
 
         ip = (env['REMOTE_ADDR'] || '').to_s.strip
         ip = env['HTTP_X_FORWARDED_FOR'].to_s.split(',').last.to_s.strip if ip.empty? && env['HTTP_X_FORWARDED_FOR']

--- a/spec/consistency_checks_spec.rb
+++ b/spec/consistency_checks_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'json'
+
+RSpec.describe Verikloak::BFF::ConsistencyChecks do
+  def jwt_with(payload)
+    header = Base64.urlsafe_encode64({}.to_json, padding: false)
+    body   = Base64.urlsafe_encode64(payload.to_json, padding: false)
+    [header, body, 'sig'].join('.')
+  end
+
+  # Build two tokens: the largest token that is <= MAX, and the first token > MAX
+  def boundary_tokens(max_bytes)
+    under = nil
+    over = nil
+    pad_len = 0
+    email = 'user@example.com'
+
+    # Brute force pad length to cross the boundary
+    while pad_len < max_bytes * 2
+      token = jwt_with({ email: email, pad: 'x' * pad_len })
+      size = token.bytesize
+      if size <= max_bytes
+        under = token
+      else
+        over = token
+        break
+      end
+      pad_len += 1
+    end
+    raise 'failed to build boundary tokens' unless under && over
+    [under, over, email]
+  end
+
+  describe '.decode_claims' do
+    it 'decodes at or below MAX_TOKEN_BYTES and skips when exceeded' do
+      max = Verikloak::BFF::Constants::MAX_TOKEN_BYTES
+      token_under, token_over, email = boundary_tokens(max)
+
+      claims_under = described_class.decode_claims(token_under)
+      expect(claims_under['email']).to eq(email)
+
+      claims_over = described_class.decode_claims(token_over)
+      expect(claims_over).to eq({})
+    end
+
+    it 'returns empty hash for nil token' do
+      expect(described_class.decode_claims(nil)).to eq({})
+    end
+  end
+end
+

--- a/spec/header_guard_spec.rb
+++ b/spec/header_guard_spec.rb
@@ -31,6 +31,27 @@ RSpec.describe Verikloak::BFF::HeaderGuard do
     [header, body, "sig"].join(".")
   end
 
+  # Build two tokens: the largest token that is <= MAX, and the first token > MAX
+  def boundary_tokens(max_bytes)
+    under = nil
+    over = nil
+    pad_len = 0
+    email = 'user@example.com'
+    while pad_len < max_bytes * 2
+      token = jwt_with({ email: email, pad: 'x' * pad_len })
+      size = token.bytesize
+      if size <= max_bytes
+        under = token
+      else
+        over = token
+        break
+      end
+      pad_len += 1
+    end
+    raise 'failed to build boundary tokens' unless under && over
+    [under, over, email]
+  end
+
   # Basic behavior (from original spec)
   it "promotes forwarded token to Authorization when preferred" do
     header "X-Forwarded-For", "127.0.0.1"
@@ -48,6 +69,33 @@ RSpec.describe Verikloak::BFF::HeaderGuard do
     expect(last_request.env["HTTP_AUTHORIZATION"]).to eq "Bearer tokmal"
   end
 
+  context "token size boundary behavior" do
+    it "enforces claims consistency at boundary size (<= MAX)" do
+      max = Verikloak::BFF::Constants::MAX_TOKEN_BYTES
+      token_under, _token_over, email = boundary_tokens(max)
+
+      @app = build_app(trusted_proxies: ["127.0.0.1"], enforce_claims_consistency: { email: :email })
+      header "X-Forwarded-For", "127.0.0.1"
+      header "X-Forwarded-Access-Token", "Bearer #{token_under}"
+      header "X-Auth-Request-Email", email
+      get "/"
+      expect(last_response.status).to eq 200
+    end
+
+    it "treats oversized token (> MAX) as empty claims and rejects when mapping requires match" do
+      max = Verikloak::BFF::Constants::MAX_TOKEN_BYTES
+      _token_under, token_over, _email = boundary_tokens(max)
+
+      @app = build_app(trusted_proxies: ["127.0.0.1"], enforce_claims_consistency: { email: :email })
+      header "X-Forwarded-For", "127.0.0.1"
+      header "X-Forwarded-Access-Token", "Bearer #{token_over}"
+      header "X-Auth-Request-Email", "user@example.com"
+      get "/"
+      expect(last_response.status).to eq 403
+      expect(last_response.headers["WWW-Authenticate"]).to include("claims_mismatch")
+    end
+  end
+
   it "rejects when both headers present and mismatch" do
     header "X-Forwarded-For", "127.0.0.1"
     header "X-Forwarded-Access-Token", "Bearer fwd"
@@ -59,7 +107,8 @@ RSpec.describe Verikloak::BFF::HeaderGuard do
 
   context "trust boundary" do
     it "requires trusted_proxies configuration" do
-      expect { build_app }.to raise_error(ArgumentError)
+      # Ensure the middleware is instantiated (Rack::Builder lazily builds on first call)
+      expect { build_app.to_app }.to raise_error(ArgumentError)
     end
 
     it "rejects requests from untrusted proxy" do

--- a/verikloak-bff.gemspec
+++ b/verikloak-bff.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.1'
 
   # Runtime dependencies
-  spec.add_dependency 'jwt', '~> 2.7'
+  spec.add_dependency 'jwt', '>= 2.7', '< 4.0'
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
   spec.add_dependency 'verikloak', '>= 0.1.2', '< 0.2'
 


### PR DESCRIPTION
## Summary
- Require explicit trusted proxy allowlist and avoid constant-time header mismatches
- Sanitize tokens before writing Authorization header
- Limit unverified JWT decoding and streamline token-header seeding defaults