### PR TITLE
Add sanitized logging and claims log-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes yet._
+
+## [0.1.2] - 2025-09-21
+
 ### Added
 - Configuration option `claims_consistency_mode` supporting `:log_only` so deployments can record mismatches without rejecting requests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
-
-_No unreleased changes yet._
-
 ## [0.1.2] - 2025-09-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- Configuration option `claims_consistency_mode` supporting `:log_only` so deployments can record mismatches without rejecting requests.
+
+### Changed
+- Sanitize log payload strings (including JWT tags) before invoking hooks or emitting to loggers to mitigate log forging attempts.
+
+### Documentation
+- Document trusted proxy hygiene, sanitized logging hooks, and the new log-only mode in the README and Rails guide.
+
 ## [0.1.1] - 2025-09-15
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-bff (0.1.1)
+    verikloak-bff (0.1.2)
       jwt (>= 2.7, < 4.0)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.1.2, < 0.2)
@@ -97,6 +97,7 @@ GEM
 PLATFORMS
   aarch64-linux-musl
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -35,6 +35,8 @@ Verikloak::BFF.configure do |c|
 
   # Claim/header consistency
   c.enforce_claims_consistency = { email: :email, user: :sub, groups: :realm_roles }
+  # Toggle log-only mode when you want observability without rejecting requests
+  # c.claims_consistency_mode = :log_only
 
   # Header names (customizable if your proxy uses different keys)
   c.forwarded_header_name = 'HTTP_X_FORWARDED_ACCESS_TOKEN'
@@ -51,7 +53,7 @@ Verikloak::BFF.configure do |c|
   c.strip_suspicious_headers = true
 
   # Structured logging hook (optional)
-  c.log_with = ->(payload) { Rails.logger.info(payload.to_json) }
+  c.log_with = ->(payload) { Rails.logger.info(payload.to_json) } # payload strings are sanitized before this hook is invoked
 end
 ```
 
@@ -110,6 +112,7 @@ Header names can be remapped via `auth_request_headers` in the initializer.
 ## 5) Validation checklist
 - XFF interpretation (leftmost/rightmost) matches your proxy’s behavior
 - `trusted_proxies` includes proxy subnets
+- `trusted_proxies` list reviewed whenever proxy topology changes
 - `require_forwarded_header` is on when you want to block non-BFF direct access
 - Authorization is seeded only when empty and no chosen token exists
 - Errors are RFC6750-style; see ERRORS.md
@@ -118,4 +121,5 @@ Header names can be remapped via `auth_request_headers` in the initializer.
 - Leaving the Rails-side ForwardedAccessToken middleware enabled (double promotion/conflicts)
 - Misconfigured `trusted_proxies` leading to `untrusted_proxy` (401)
 - Missing forwarded token with `require_forwarded_header: true` (401)
+- Forgetting to set `claims_consistency_mode: :log_only` in environments where mismatches should not block traffic
 

--- a/lib/verikloak/bff/configuration.rb
+++ b/lib/verikloak/bff/configuration.rb
@@ -30,7 +30,8 @@ module Verikloak
                     :enforce_header_consistency, :enforce_claims_consistency,
                     :strip_suspicious_headers, :xff_strategy, :clock_skew_leeway,
                     :logger, :token_header_priority, :peer_preference,
-                    :forwarded_header_name, :auth_request_headers, :log_with
+                    :forwarded_header_name, :auth_request_headers, :log_with,
+                    :claims_consistency_mode
 
       # enforce_claims_consistency example:
       # { email: :email, user: :sub, groups: :realm_roles }
@@ -40,6 +41,7 @@ module Verikloak
         @require_forwarded_header = false
         @enforce_header_consistency = true
         @enforce_claims_consistency = {}
+        @claims_consistency_mode = :enforce
         @strip_suspicious_headers = true
         @xff_strategy = :rightmost
         @peer_preference = :remote_then_xff

--- a/lib/verikloak/bff/header_guard.rb
+++ b/lib/verikloak/bff/header_guard.rb
@@ -66,7 +66,9 @@ module Verikloak
           sanitized = sanitize_string(value)
           sanitized.empty? ? nil : sanitized
         when Array
-          value.map { |item| item.is_a?(String) ? sanitize_string(item) : item }
+          sanitized = value.map { |item| item.is_a?(String) ? sanitize_string(item) : item }
+          sanitized.reject! { |item| item.nil? || (item.is_a?(String) && item.empty?) }
+          sanitized.empty? ? nil : sanitized
         else
           value
         end

--- a/lib/verikloak/bff/header_guard.rb
+++ b/lib/verikloak/bff/header_guard.rb
@@ -37,10 +37,10 @@ module Verikloak
         aud = payload['aud']
         aud = aud.join(' ') if aud.is_a?(Array)
         {
-          sub: sanitize_claim_value(payload['sub']),
-          iss: sanitize_claim_value(payload['iss']),
-          aud: sanitize_claim_value(aud),
-          kid: sanitize_claim_value(header['kid'])
+          sub: sanitize_log_field(payload['sub']&.to_s),
+          iss: sanitize_log_field(payload['iss']&.to_s),
+          aud: sanitize_log_field(aud&.to_s),
+          kid: sanitize_log_field(header['kid']&.to_s)
         }.compact
       rescue StandardError
         {}
@@ -76,13 +76,6 @@ module Verikloak
 
       def sanitize_string(value)
         value.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '').gsub(LOG_CONTROL_CHARS, '')
-      end
-
-      def sanitize_claim_value(value)
-        return if value.nil?
-
-        sanitized = sanitize_string(value.to_s)
-        sanitized.empty? ? nil : sanitized
       end
     end
 

--- a/lib/verikloak/bff/header_guard.rb
+++ b/lib/verikloak/bff/header_guard.rb
@@ -256,6 +256,7 @@ module Verikloak
       # @return [Boolean]
       def claims_consistency_log_only?
         mode = @config.claims_consistency_mode || :enforce
+        mode = mode.to_sym if mode.is_a?(String)
         mode = :enforce unless %i[enforce log_only].include?(mode)
         mode == :log_only
       end

--- a/lib/verikloak/bff/version.rb
+++ b/lib/verikloak/bff/version.rb
@@ -5,6 +5,6 @@
 # @return [String]
 module Verikloak
   module BFF
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end

--- a/spec/header_guard_spec.rb
+++ b/spec/header_guard_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe Verikloak::BFF::HeaderGuard do
         trusted_proxies: ["127.0.0.1"],
         prefer_forwarded: true,
         enforce_claims_consistency: { email: :email },
-        claims_consistency_mode: :log_only,
+        claims_consistency_mode: "log_only",
         log_with: ->(payload) { events << payload }
       )
 


### PR DESCRIPTION
## Summary
- sanitize all log payload strings (including unverified JWT tags) before emitting to loggers or hooks
- introduce a `claims_consistency_mode` configuration flag that can log mismatches without rejecting requests and cover it with specs
- document sanitized logging guidance, trusted proxy hygiene, and the new log-only mode in the README and Rails guide