### PR TITLE
Expose shared header normalization helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes yet._
+
+## [0.2.0] - 2025-09-22
+
 ### Added
 - `Verikloak::HeaderSources` module for shared header normalization (consumable by verikloak-rails and other adapters).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
-
-_No unreleased changes yet._
-
 ## [0.2.0] - 2025-09-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- `Verikloak::HeaderSources` module for shared header normalization (consumable by verikloak-rails and other adapters).
+
+### Changed
+- `Configuration#token_header_priority=` now normalizes and deduplicates entries, reusing the shared helper and ignoring `HTTP_AUTHORIZATION` automatically.
+- `forwarded_header_name` assignments trigger re-normalization of token priority lists to keep middleware aligned across gems.
+
 ## [0.1.2] - 2025-09-21
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    verikloak-bff (0.1.2)
+    verikloak-bff (0.2.0)
       jwt (>= 2.7, < 4.0)
       rack (>= 2.2, < 4.0)
-      verikloak (>= 0.1.2, < 0.2)
+      verikloak (>= 0.1.5, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -22,6 +22,8 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
     json (2.13.2)
     jwt (2.10.2)
       base64
@@ -89,10 +91,11 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
     uri (1.0.3)
-    verikloak (0.1.2)
+    verikloak (0.1.5)
       faraday (>= 2.0, < 3.0)
+      faraday-retry (>= 2.0, < 3.0)
       json (~> 2.6)
-      jwt (~> 2.7)
+      jwt (>= 2.7, < 4.0)
 
 PLATFORMS
   aarch64-linux-musl

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See `examples/rack.ru` for a tiny Rack app demo.
 | `peer_preference`            | Symbol (`:remote_then_xff`/`:xff_only`) | `:remote_then_xff` | Whether to prefer `REMOTE_ADDR` before falling back to XFF. |
 | `clock_skew_leeway`          | Integer (seconds)                    | `30`         | Reserved for small exp/nbf skew handled by core verifier. |
 | `logger`                     | `Logger` or `nil`                    | `nil`        | Logger for audit tags (`rid`, `sub`, `kid`, `iss/aud`). |
-| `token_header_priority`      | Array[String]                        | `['HTTP_X_FORWARDED_ACCESS_TOKEN']` | When Authorization is empty and no token chosen, seed it from these env headers in order. `HTTP_AUTHORIZATION` is ignored as a source; forwarded header is considered only from trusted peers. |
+| `token_header_priority`      | Array[String]                        | `['HTTP_X_FORWARDED_ACCESS_TOKEN']` | When Authorization is empty and no token chosen, seed it from these env headers in order. Values are normalized via `Verikloak::HeaderSources`; `HTTP_AUTHORIZATION` is ignored as a source. |
 | `forwarded_header_name`      | String                               | `HTTP_X_FORWARDED_ACCESS_TOKEN` | Env key for forwarded access token. |
 | `auth_request_headers`       | Hash                                 | see code     | Mapping for `X-Auth-Request-*` env keys: `{ email, user, groups }`. |
 
@@ -82,6 +82,7 @@ For full reverse proxy examples (Nginx auth_request / oauth2-proxy), see [docs/r
 - Authorization seeding from priority headers
   - When no token is chosen and `HTTP_AUTHORIZATION` is empty, the middleware consults `token_header_priority` to seed Authorization.
   - `HTTP_AUTHORIZATION` itself is never used as a source; forwarded headers are considered only from trusted peers.
+  - Other gems can `require 'verikloak/header_sources'` to reuse the same normalization helpers when sharing configuration defaults.
 
 - Observability helpers
   - Downstream can inspect `env['verikloak.bff.token']` (chosen token, unverified) and `env['verikloak.bff.selected_peer']` (peer IP selected for trust decisions).

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -107,7 +107,7 @@ Enable via:
 enforce_claims_consistency: { email: :email, user: :sub, groups: :realm_roles }
 ```
 
-Header names can be remapped via `auth_request_headers` in the initializer.
+Header names can be remapped via `auth_request_headers` in the initializer. Header keys and priority lists are normalized via `Verikloak::HeaderSources`, so symbols, mixed-case, or dash-separated keys are acceptable.
 
 ## 5) Validation checklist
 - XFF interpretation (leftmost/rightmost) matches your proxy’s behavior

--- a/lib/verikloak/bff/configuration.rb
+++ b/lib/verikloak/bff/configuration.rb
@@ -67,12 +67,14 @@ module Verikloak
       end
 
       # Override forwarded header name while re-normalizing the token priority list.
+      # When the forwarded header changes, downstream priority normalization must
+      # be refreshed because the forwarded value participates in that list.
       #
       # @param header [String, Symbol]
       # @return [void]
       def forwarded_header_name=(header)
         @forwarded_header_name = Verikloak::HeaderSources.normalize_env_key(header)
-        self.token_header_priority = @token_header_priority
+        renormalize_token_priority!
       end
 
       # Assign token header priority list using shared normalization logic.
@@ -82,6 +84,16 @@ module Verikloak
       def token_header_priority=(priority)
         normalized, = Verikloak::HeaderSources.normalize_priority(priority, forwarded_header: @forwarded_header_name)
         @token_header_priority = normalized
+      end
+
+      private
+
+      # Re-apply token header normalization so it reflects the current forwarded header.
+      #
+      # @return [void]
+      def renormalize_token_priority!
+        # Refresh the normalized list so it reflects the new forwarded header name.
+        self.token_header_priority = @token_header_priority
       end
     end
   end

--- a/lib/verikloak/bff/header_guard.rb
+++ b/lib/verikloak/bff/header_guard.rb
@@ -15,6 +15,7 @@ require 'rack/utils'
 require 'json'
 require 'jwt'
 require 'digest'
+require 'verikloak/header_sources'
 require 'verikloak/bff/configuration'
 require 'verikloak/bff/errors'
 require 'verikloak/bff/proxy_trust'
@@ -324,8 +325,8 @@ module Verikloak
       # @return [String, nil]
       def resolve_first_token_header(env)
         candidates = Array(@config.token_header_priority).dup
-        candidates -= ['HTTP_AUTHORIZATION']
-        fwd_key = 'HTTP_X_FORWARDED_ACCESS_TOKEN'
+        candidates -= [Verikloak::HeaderSources::AUTHORIZATION_HEADER]
+        fwd_key = @config.forwarded_header_name || Verikloak::HeaderSources::DEFAULT_FORWARDED_HEADER
         if candidates.include?(fwd_key) && !ProxyTrust.from_trusted_proxy?(env, @config.trusted_proxies)
           candidates -= [fwd_key]
         end

--- a/lib/verikloak/bff/version.rb
+++ b/lib/verikloak/bff/version.rb
@@ -5,6 +5,6 @@
 # @return [String]
 module Verikloak
   module BFF
-    VERSION = '0.1.2'
+    VERSION = '0.2.0'
   end
 end

--- a/lib/verikloak/header_sources.rb
+++ b/lib/verikloak/header_sources.rb
@@ -4,6 +4,7 @@
 # names and token source priority lists. Extracted to allow other gems (such as
 # verikloak-rails) to consume the same normalization logic.
 module Verikloak
+  # Provides normalization helpers for Rack env header keys and token priority lists.
   module HeaderSources
     module_function
 
@@ -36,7 +37,7 @@ module Verikloak
       forwarded_env = normalize_env_key(forwarded_header)
       items = Array(priority).flatten
 
-      normalized = Array(items).map { |value| normalize_env_key(value) }.reject(&:empty?)
+      normalized = items.map { |value| normalize_env_key(value) }.reject(&:empty?)
       normalized = [forwarded_env] if normalized.empty?
       normalized = normalized.reject { |key| drop_authorization && key == AUTHORIZATION_HEADER }
 

--- a/lib/verikloak/header_sources.rb
+++ b/lib/verikloak/header_sources.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Helpers shared across verikloak middleware for normalizing Rack env header
+# names and token source priority lists. Extracted to allow other gems (such as
+# verikloak-rails) to consume the same normalization logic.
+module Verikloak
+  module HeaderSources
+    module_function
+
+    DEFAULT_FORWARDED_HEADER = 'HTTP_X_FORWARDED_ACCESS_TOKEN'
+    AUTHORIZATION_HEADER     = 'HTTP_AUTHORIZATION'
+
+    # Normalize a Rack env header key, accepting symbols, mixed case, or dash
+    # separated names and returning an upper-case HTTP_* variant.
+    #
+    # @param header [String, Symbol, nil]
+    # @return [String] normalized env key or empty string when blank
+    def normalize_env_key(header)
+      key = header.to_s.strip
+      return '' if key.empty?
+
+      key = key.tr('-', '_').upcase
+      key = "HTTP_#{key}" unless key.start_with?('HTTP_')
+      key
+    end
+
+    # Normalize a token priority list by stripping blanks, rejecting
+    # Authorization as a source, and deduplicating entries while preserving
+    # order.
+    #
+    # @param priority [Array<String, Symbol>, String, Symbol, nil]
+    # @param forwarded_header [String, Symbol]
+    # @param drop_authorization [Boolean]
+    # @return [Array(Array<String>, String)] normalized priority and forwarded key
+    def normalize_priority(priority, forwarded_header: DEFAULT_FORWARDED_HEADER, drop_authorization: true)
+      forwarded_env = normalize_env_key(forwarded_header)
+      items = Array(priority).flatten
+
+      normalized = Array(items).map { |value| normalize_env_key(value) }.reject(&:empty?)
+      normalized = [forwarded_env] if normalized.empty?
+      normalized = normalized.reject { |key| drop_authorization && key == AUTHORIZATION_HEADER }
+
+      deduped = []
+      normalized.each do |key|
+        deduped << key unless deduped.include?(key)
+      end
+
+      [deduped.freeze, forwarded_env]
+    end
+
+    # Default priority list using the provided forwarded header name.
+    #
+    # @param forwarded_header [String, Symbol]
+    # @return [Array<String>] normalized default priority
+    def default_priority(forwarded_header: DEFAULT_FORWARDED_HEADER)
+      normalize_priority([forwarded_header], forwarded_header: forwarded_header).first
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Verikloak::BFF::Configuration do
+  describe '#initialize' do
+    it 'normalizes default forwarded header and token priority' do
+      config = described_class.new
+
+      expect(config.forwarded_header_name).to eq('HTTP_X_FORWARDED_ACCESS_TOKEN')
+      expect(config.token_header_priority).to eq(['HTTP_X_FORWARDED_ACCESS_TOKEN'])
+    end
+  end
+
+  describe '#token_header_priority=' do
+    it 'normalizes keys and strips Authorization' do
+      config = described_class.new
+
+      config.token_header_priority = [:http_x_custom, ' HTTP_AUTHORIZATION ']
+
+      expect(config.token_header_priority).to eq(['HTTP_X_CUSTOM'])
+    end
+
+    it 'preserves explicit order after normalization' do
+      config = described_class.new
+
+      config.token_header_priority = %w[x-token x-forwarded-access-token]
+
+      expect(config.token_header_priority).to eq([
+        'HTTP_X_TOKEN',
+        'HTTP_X_FORWARDED_ACCESS_TOKEN'
+      ])
+    end
+  end
+
+  describe '#forwarded_header_name=' do
+    it 'reapplies normalization to priority list' do
+      config = described_class.new
+      config.token_header_priority = ['X-Token']
+
+      config.forwarded_header_name = 'x-authz'
+
+      expect(config.forwarded_header_name).to eq('HTTP_X_AUTHZ')
+      expect(config.token_header_priority).to eq([
+        'HTTP_X_TOKEN'
+      ])
+    end
+  end
+end

--- a/verikloak-bff.gemspec
+++ b/verikloak-bff.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   # Runtime dependencies
   spec.add_dependency 'jwt', '>= 2.7', '< 4.0'
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
-  spec.add_dependency 'verikloak', '>= 0.1.2', '< 0.2'
+  spec.add_dependency 'verikloak', '>= 0.1.5', '< 1.0.0'
 
   # Metadata for RubyGems
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
## Summary
- add `Verikloak::HeaderSources` so Rails and other adapters can share header normalization rules
- normalize `token_header_priority`/`forwarded_header_name` through the shared helper and add configuration specs
- document the shared helper and normalization behavior in the README, Rails guide, and changelog