### PR TITLE
Improve middleware insertion safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.2] - 2025-09-23
+
+### Changed
+- Improved middleware class extraction logic to reduce code duplication while maintaining functionality
+
 ## [0.2.1] - 2025-09-23
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-bff (0.2.1)
+    verikloak-bff (0.2.2)
       jwt (>= 2.7, < 4.0)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.2.0, < 1.0.0)

--- a/lib/verikloak/bff/rails.rb
+++ b/lib/verikloak/bff/rails.rb
@@ -97,19 +97,26 @@ module Verikloak
         def middleware_matches_core?(middleware)
           candidate = middleware.is_a?(Array) ? middleware.first : middleware
 
-          klass = if candidate.respond_to?(:klass)
-                    candidate.klass
-                  elsif candidate.is_a?(Class)
-                    candidate
-                  elsif candidate.respond_to?(:name)
-                    candidate.name
-                  else
-                    candidate
-                  end
+          klass = extract_middleware_class(candidate)
 
           klass == ::Verikloak::Middleware || klass.to_s == 'Verikloak::Middleware'
         end
 
+        # Extracts the class or class-like identifier from a middleware candidate.
+        #
+        # @param candidate [Object]
+        # @return [Class, String, Object]
+        def extract_middleware_class(candidate)
+          if candidate.respond_to?(:klass)
+            candidate.klass
+          elsif candidate.is_a?(Class)
+            candidate
+          elsif candidate.respond_to?(:name)
+            candidate.name
+          else
+            candidate
+          end
+        end
         # Checks if the error indicates missing core Verikloak middleware
         #
         # Examines a RuntimeError to determine if it was caused by attempting

--- a/lib/verikloak/bff/rails.rb
+++ b/lib/verikloak/bff/rails.rb
@@ -50,7 +50,7 @@ module Verikloak
         # When the core gem exposes +auto_insert_bff_header_guard+, respect that flag so
         # consumers can opt out of automatic middleware wiring without triggering warnings.
         # Any failures while reading configuration default to enabling insertion in order
-        # to preserve the previous behaviour.
+        # to preserve the previous behavior.
         #
         # @return [Boolean]
         def auto_insert_enabled?

--- a/lib/verikloak/bff/rails.rb
+++ b/lib/verikloak/bff/rails.rb
@@ -111,14 +111,13 @@ module Verikloak
         def extract_middleware_class(candidate)
           if candidate.respond_to?(:klass)
             candidate.klass
-          elsif candidate.is_a?(Class)
-            candidate
           elsif candidate.respond_to?(:name)
             candidate.name
           else
             candidate
           end
         end
+
         # Checks if the error indicates missing core Verikloak middleware
         #
         # Examines a RuntimeError to determine if it was caused by attempting
@@ -156,11 +155,7 @@ module Verikloak
             [verikloak-bff] Skipping Verikloak::BFF::HeaderGuard insertion because Verikloak::Middleware is not present. Configure verikloak-rails discovery settings and restart once core verification is enabled.
           MSG
 
-          if logger
-            logger.warn(message)
-          else
-            warn(message)
-          end
+          logger ? logger.warn(message) : warn(message)
         end
       end
     end

--- a/lib/verikloak/bff/rails.rb
+++ b/lib/verikloak/bff/rails.rb
@@ -99,7 +99,9 @@ module Verikloak
 
           klass = extract_middleware_class(candidate)
 
-          klass == ::Verikloak::Middleware || klass.to_s == 'Verikloak::Middleware'
+          klass == ::Verikloak::Middleware ||
+            (klass.is_a?(String) && klass == 'Verikloak::Middleware') ||
+            (klass.respond_to?(:name) && klass.name == 'Verikloak::Middleware')
         end
 
         # Extracts the class or class-like identifier from a middleware candidate.

--- a/lib/verikloak/bff/version.rb
+++ b/lib/verikloak/bff/version.rb
@@ -5,6 +5,6 @@
 # @return [String]
 module Verikloak
   module BFF
-    VERSION = '0.2.1'
+    VERSION = '0.2.2'
   end
 end

--- a/spec/rails_middleware_spec.rb
+++ b/spec/rails_middleware_spec.rb
@@ -3,17 +3,32 @@
 RSpec.describe Verikloak::BFF::Rails::Middleware do
   module Verikloak
     class Middleware; end
+
+    class << self
+      attr_accessor :config
+    end
   end
 
   describe '.insert_after_core' do
-    let(:stack) { instance_double('MiddlewareStack') }
+    let(:stack) { double('MiddlewareStack') }
 
     it 'inserts the header guard when the core middleware is present' do
+      allow(stack).to receive(:each).and_yield(double('Entry', klass: Verikloak::Middleware))
       expect(stack).to receive(:insert_after).with(Verikloak::Middleware, Verikloak::BFF::HeaderGuard)
       expect(described_class.insert_after_core(stack, logger: nil)).to be(true)
     end
 
     it 'skips insertion with a warning when the core middleware is missing' do
+      allow(stack).to receive(:each)
+      logger = instance_double('Logger')
+      expect(logger).to receive(:warn).with(a_string_matching('Skipping Verikloak::BFF::HeaderGuard insertion'))
+      expect(stack).not_to receive(:insert_after)
+
+      expect(described_class.insert_after_core(stack, logger: logger)).to be(false)
+    end
+
+    it 'logs and skips when insertion fails because the core middleware is missing' do
+      allow(stack).to receive(:each).and_yield(double('Entry', klass: Verikloak::Middleware))
       error = RuntimeError.new('No such middleware to insert after: Verikloak::Middleware')
       allow(stack).to receive(:insert_after).and_raise(error)
       logger = instance_double('Logger')
@@ -23,11 +38,22 @@ RSpec.describe Verikloak::BFF::Rails::Middleware do
     end
 
     it 're-raises unexpected runtime errors' do
+      allow(stack).to receive(:each).and_yield(double('Entry', klass: Verikloak::Middleware))
       allow(stack).to receive(:insert_after).and_raise(RuntimeError, 'boom')
 
       expect {
         described_class.insert_after_core(stack, logger: nil)
       }.to raise_error(RuntimeError, 'boom')
+    end
+
+    it 'respects auto_insert_bff_header_guard configuration' do
+      Verikloak.config = double('Config', auto_insert_bff_header_guard: false)
+      allow(stack).to receive(:each).and_yield(double('Entry', klass: Verikloak::Middleware))
+      expect(stack).not_to receive(:insert_after)
+
+      expect(described_class.insert_after_core(stack, logger: nil)).to be(false)
+    ensure
+      Verikloak.config = nil
     end
   end
 end


### PR DESCRIPTION
## Summary
- respect the core `auto_insert_bff_header_guard` flag before wiring the header guard
- detect whether `Verikloak::Middleware` is present and log a warning instead of raising when it is missing
- expand middleware insertion specs to cover configuration, detection, and rescue paths