### PR TITLE
Add install generator for Rails integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+---
 
-## [Unreleased]
+## [0.2.3] - 2025-09-23
 
 ### Changed
 - Stop inserting `Verikloak::BFF::HeaderGuard` automatically via the Railtie and provide a `rails g verikloak:bff:install` generator that drops an initializer to opt in when the core middleware is ready.
-
----
 
 ## [0.2.2] - 2025-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Changed
+- Stop inserting `Verikloak::BFF::HeaderGuard` automatically via the Railtie and provide a `rails g verikloak:bff:install` generator that drops an initializer to opt in when the core middleware is ready.
+
 ---
 
 ## [0.2.2] - 2025-09-23

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-bff (0.2.2)
+    verikloak-bff (0.2.3)
       jwt (>= 2.7, < 4.0)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.2.0, < 1.0.0)

--- a/README.md
+++ b/README.md
@@ -31,12 +31,16 @@ use Verikloak::BFF::HeaderGuard, trusted_proxies: ['127.0.0.1', '10.0.0.0/8']
 ```
 
 ### Rails Applications
-Simply add to your Gemfile and the middleware will be automatically integrated:
+Add the gem to your Gemfile and run the install generator to drop an initializer that wires the middleware into Rails:
 ```ruby
 gem 'verikloak-bff'
 ```
 
-The gem automatically inserts `Verikloak::BFF::HeaderGuard` into the Rails middleware stack after the core `Verikloak::Middleware`. If the core middleware is not present (e.g., discovery not configured), it gracefully skips insertion with a warning, allowing Rails to boot normally.
+```sh
+bin/rails g verikloak:bff:install
+```
+
+The generated initializer inserts `Verikloak::BFF::HeaderGuard` after the core `Verikloak::Middleware` during boot. If the core middleware is not present (for example, when verikloak-rails has not been fully configured yet), the initializer logs a warning and allows Rails to boot normally.
 
 For detailed configuration, proxy setup examples, and troubleshooting, see [docs/rails.md](docs/rails.md).
 

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -2,12 +2,7 @@
 
 This guide explains how to use verikloak-bff together with Verikloak (core) and verikloak-rails in a Rails application.
 
-To avoid boot errors while the core middleware is being installed, the gem no longer inserts its header guard automatically.
-Instead, run `bin/rails g verikloak:bff:install` after adding the gem. The generator creates an initializer that inserts
-`Verikloak::BFF::HeaderGuard` immediately before the core `Verikloak::Middleware` during boot. If the core middleware has not
-been registered (for example because discovery settings are missing), the initializer logs a warning and skips insertion so the
-application can still boot. Once discovery is configured and the core middleware is enabled, restart the application to
-activate the BFF guard.
+To avoid boot errors while the core middleware is being installed, the gem no longer inserts its header guard automatically. Instead, run `bin/rails g verikloak:bff:install` after adding the gem. The generator creates an initializer that inserts `Verikloak::BFF::HeaderGuard` immediately before the core `Verikloak::Middleware` during boot. If the core middleware has not been registered (for example because discovery settings are missing), the initializer logs a warning and skips insertion so the application can still boot. Once discovery is configured and the core middleware is enabled, restart the application to activate the BFF guard.
 
 ## Prerequisites
 - Ruby >= 3.1, Rails 6.1+ (7.x recommended)
@@ -25,8 +20,7 @@ gem 'verikloak-bff'
 ```
 
 ## 2) BFF configuration
-The generator creates `config/initializers/verikloak_bff.rb`. Extend the file with configuration suitable for your proxy
-topology. The example below uses safe defaults for a proxy chain that appends client IP to XFF.
+The generator creates `config/initializers/verikloak_bff.rb`. Extend the file with configuration suitable for your proxy topology. The example below uses safe defaults for a proxy chain that appends client IP to XFF.
 
 ```ruby
 Verikloak::BFF.configure do |c|

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -1,10 +1,13 @@
 # Rails Integration Guide
 
 This guide explains how to use verikloak-bff together with Verikloak (core) and verikloak-rails in a Rails application.
-When Rails boots, verikloak-bff automatically inserts its `HeaderGuard` immediately before the core `Verikloak::Middleware`.
-If the core middleware has not been registered (for example because discovery settings are missing), verikloak-bff logs a
-warning and skips insertion so that the application can still boot. Once discovery is configured and the core middleware is
-enabled, restart the application to activate the BFF guard.
+
+To avoid boot errors while the core middleware is being installed, the gem no longer inserts its header guard automatically.
+Instead, run `bin/rails g verikloak:bff:install` after adding the gem. The generator creates an initializer that inserts
+`Verikloak::BFF::HeaderGuard` immediately before the core `Verikloak::Middleware` during boot. If the core middleware has not
+been registered (for example because discovery settings are missing), the initializer logs a warning and skips insertion so the
+application can still boot. Once discovery is configured and the core middleware is enabled, restart the application to
+activate the BFF guard.
 
 ## Prerequisites
 - Ruby >= 3.1, Rails 6.1+ (7.x recommended)
@@ -22,7 +25,8 @@ gem 'verikloak-bff'
 ```
 
 ## 2) BFF configuration
-Create an initializer (e.g., `config/initializers/verikloak_bff.rb`). The example below uses safe defaults for a proxy chain that appends client IP to XFF.
+The generator creates `config/initializers/verikloak_bff.rb`. Extend the file with configuration suitable for your proxy
+topology. The example below uses safe defaults for a proxy chain that appends client IP to XFF.
 
 ```ruby
 Verikloak::BFF.configure do |c|

--- a/lib/generators/verikloak/bff/install/install_generator.rb
+++ b/lib/generators/verikloak/bff/install/install_generator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails/generators/base'
+
+module Verikloak
+  module BFF
+    module Generators
+      # Generator that installs a Rails initializer responsible for
+      # wiring Verikloak::BFF::HeaderGuard into the middleware stack.
+      class InstallGenerator < ::Rails::Generators::Base
+        source_root File.expand_path('templates', __dir__)
+
+        class_option :initializer, type: :string,
+                                   default: 'config/initializers/verikloak_bff.rb',
+                                   desc: 'Path for the generated initializer'
+
+        def create_initializer
+          template 'initializer.rb.tt', initializer_path
+        end
+
+        private
+
+        def initializer_path
+          options[:initializer]
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/verikloak/bff/install/install_generator.rb
+++ b/lib/generators/verikloak/bff/install/install_generator.rb
@@ -4,22 +4,50 @@ require 'rails/generators/base'
 
 module Verikloak
   module BFF
+    # Namespace for Rails generators related to Verikloak BFF
     module Generators
-      # Generator that installs a Rails initializer responsible for
-      # wiring Verikloak::BFF::HeaderGuard into the middleware stack.
+      # Rails generator for installing Verikloak BFF middleware integration.
+      #
+      # This generator creates a Rails initializer that safely inserts the
+      # Verikloak::BFF::HeaderGuard middleware into the Rails middleware stack.
+      # It replaces automatic middleware insertion to avoid boot failures when
+      # core Verikloak middleware is not yet configured.
+      #
+      # @example Basic usage
+      #   rails g verikloak:bff:install
+      #
+      # @example Custom initializer path
+      #   rails g verikloak:bff:install --initializer=config/initializers/custom_bff.rb
+      #
+      # @see Verikloak::BFF::Rails::Middleware
       class InstallGenerator < ::Rails::Generators::Base
         source_root File.expand_path('templates', __dir__)
 
+        # Configuration option for specifying the initializer file path.
+        #
+        # @option options [String] :initializer ('config/initializers/verikloak_bff.rb')
+        #   The path where the initializer file will be created
         class_option :initializer, type: :string,
                                    default: 'config/initializers/verikloak_bff.rb',
                                    desc: 'Path for the generated initializer'
 
+        # Creates the Rails initializer file from template.
+        #
+        # Generates a Rails initializer that safely inserts the HeaderGuard
+        # middleware into the middleware stack with proper error handling.
+        # The initializer uses Verikloak::BFF::Rails::Middleware.insert_after_core
+        # to ensure graceful handling when core middleware is missing.
+        #
+        # @return [void]
         def create_initializer
           template 'initializer.rb.tt', initializer_path
         end
 
         private
 
+        # Returns the path where the initializer should be created.
+        #
+        # @return [String] The initializer file path from options
         def initializer_path
           options[:initializer]
         end

--- a/lib/generators/verikloak/bff/install/templates/initializer.rb.tt
+++ b/lib/generators/verikloak/bff/install/templates/initializer.rb.tt
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Configure verikloak-bff to insert its HeaderGuard middleware only after the
+# Verikloak core middleware is present. This avoids boot errors when the core
+# gem has not yet been installed.
+Rails.application.config.after_initialize do
+  logger = defined?(Rails.logger) ? Rails.logger : nil
+  Verikloak::BFF::Rails::Middleware.insert_after_core(
+    Rails.application.config.middleware,
+    logger: logger
+  )
+end

--- a/lib/verikloak/bff/railtie.rb
+++ b/lib/verikloak/bff/railtie.rb
@@ -5,17 +5,23 @@ require_relative 'rails'
 module Verikloak
   # Module providing Verikloak BFF (Backend for Frontend) functionality
   module BFF
-    # Railtie class for integrating Verikloak BFF with Rails applications.
+    # Railtie for integrating Verikloak BFF with Rails applications.
     #
-    # The Railtie no longer inserts middleware automatically because doing so
-    # during `rails g verikloak:install` caused boot failures when the core
-    # Verikloak middleware had not yet been configured. Applications now opt-in
-    # to the HeaderGuard middleware by running `rails g verikloak:bff:install`,
-    # which drops an initializer that performs the insertion during boot.
+    # This Railtie provides access to the BFF installation generator instead of
+    # automatically inserting middleware, which could cause boot failures when
+    # core Verikloak middleware is not yet configured.
+    #
+    # @example Installing BFF middleware
+    #   rails g verikloak:bff:install
+    #
+    # @see Verikloak::BFF::Rails::Middleware
     class Railtie < ::Rails::Railtie
-      # Expose the install generator when Rails generator infrastructure is
-      # available. This keeps the generator optional for non-Rails consumers
-      # while still making it discoverable to `rails g`.
+      # Loads the install generator when Rails generator infrastructure is available.
+      #
+      # Makes the `verikloak:bff:install` generator discoverable through `rails g`
+      # while keeping generators optional for non-Rails environments.
+      #
+      # @return [void]
       initializer 'verikloak.bff.load_generators' do
         next unless defined?(Rails::Generators)
 

--- a/lib/verikloak/bff/railtie.rb
+++ b/lib/verikloak/bff/railtie.rb
@@ -5,29 +5,21 @@ require_relative 'rails'
 module Verikloak
   # Module providing Verikloak BFF (Backend for Frontend) functionality
   module BFF
-    # Railtie class for integrating Verikloak BFF middleware into Rails applications
+    # Railtie class for integrating Verikloak BFF with Rails applications.
     #
-    # This class automatically inserts Verikloak::BFF::Rails::Middleware into the
-    # Rails initialization process. The middleware is inserted after the
-    # 'verikloak.middleware' initializer and configured with an appropriate logger.
-    #
-    # @example Automatic initialization in Rails applications
-    #   # Simply adding verikloak-bff to Gemfile automatically enables it
-    #   gem 'verikloak-bff'
-    #
-    # @see Verikloak::BFF::Rails::Middleware
+    # The Railtie no longer inserts middleware automatically because doing so
+    # during `rails g verikloak:install` caused boot failures when the core
+    # Verikloak middleware had not yet been configured. Applications now opt-in
+    # to the HeaderGuard middleware by running `rails g verikloak:bff:install`,
+    # which drops an initializer that performs the insertion during boot.
     class Railtie < ::Rails::Railtie
-      # Initializer that inserts Verikloak BFF middleware into Rails application
-      #
-      # This initializer runs after 'verikloak.middleware' and inserts
-      # Verikloak::BFF::Rails::Middleware at the appropriate position.
-      # Uses Rails.logger as the logger if available.
-      #
-      # @param app [Rails::Application] Rails application instance
-      initializer 'verikloak.bff.insert_middleware', after: 'verikloak.middleware' do |app|
-        logger = ::Rails.logger if defined?(::Rails.logger)
+      # Expose the install generator when Rails generator infrastructure is
+      # available. This keeps the generator optional for non-Rails consumers
+      # while still making it discoverable to `rails g`.
+      initializer 'verikloak.bff.load_generators' do
+        next unless defined?(Rails::Generators)
 
-        Verikloak::BFF::Rails::Middleware.insert_after_core(app.config.middleware, logger: logger)
+        require_relative '../../generators/verikloak/bff/install/install_generator'
       end
     end
   end

--- a/lib/verikloak/bff/version.rb
+++ b/lib/verikloak/bff/version.rb
@@ -5,6 +5,6 @@
 # @return [String]
 module Verikloak
   module BFF
-    VERSION = '0.2.2'
+    VERSION = '0.2.3'
   end
 end


### PR DESCRIPTION
## Summary
- stop inserting the BFF header guard via the railtie and load generators only when available
- add a `verikloak:bff:install` generator that drops an initializer to opt into middleware insertion
- refresh README, Rails guide, and changelog to describe the new workflow