### PR TITLE
Change configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.0] - 2025-01-01
+
+### Added
+- **`disabled` configuration option**: Explicitly disable the middleware in pass-through mode. When `disabled: false` (default) and `trusted_proxies` is not configured, a `ConfigurationError` is raised at startup.
+
+### Changed
+- **BREAKING**: `trusted_proxies` is now **required** when `disabled: false`. Previously, an empty `trusted_proxies` would silently disable the middleware (fail-open). Now it raises `Verikloak::BFF::HeaderGuard::ConfigurationError` to prevent unintended security gaps.
+
+### Fixed
+- **Security**: Prevent fail-open vulnerability where unset `trusted_proxies` could silently bypass proxy trust validation.
+
+---
+
 ## [0.2.6] - 2025-12-31
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-bff (0.2.6)
+    verikloak-bff (0.3.0)
       jwt (>= 2.7, < 4.0)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.3.0, < 1.0.0)

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -52,7 +52,7 @@ end
 
 ## 3) Configure BFF
 
-Edit the generated initializer to set `trusted_proxies` (required) and customize other options:
+Edit the generated initializer to set `trusted_proxies` (required unless `disabled: true`) and customize other options:
 
 ```ruby
 Verikloak::BFF.configure do |c|
@@ -91,7 +91,7 @@ Verikloak::BFF.configure do |c|
 end
 ```
 
-`trusted_proxies` must not be left empty; the middleware raises an error when no allowlist is provided.
+`trusted_proxies` must not be left empty; the middleware raises an error when no allowlist is provided. To explicitly disable the middleware (pass-through mode), set `disabled: true`.
 
 ## 4) Reverse proxy examples
 

--- a/lib/generators/verikloak/bff/install/templates/initializer.rb.erb
+++ b/lib/generators/verikloak/bff/install/templates/initializer.rb.erb
@@ -20,13 +20,27 @@
 #
 Verikloak::BFF.configure do |config|
   # ==========================================================================
-  # Trust Boundary (REQUIRED)
+  # Disable Middleware (Development/Testing Only)
+  # ==========================================================================
+  # Explicitly disable the middleware (pass-through mode).
+  # When disabled: false (default), trusted_proxies MUST be configured.
+  #
+  # SECURITY WARNING: Only set to true in development/test environments.
+  # Production deployments should ALWAYS configure trusted_proxies.
+  #
+  # config.disabled = ENV.fetch('VERIKLOAK_BFF_DISABLED', 'false') == 'true'
+
+  # ==========================================================================
+  # Trust Boundary (REQUIRED when disabled: false)
   # ==========================================================================
   # Allowlist for trusted proxy peers. Requests from untrusted peers are rejected.
   # Supports IP addresses, CIDR ranges, Regexp, or Proc.
   #
   # SECURITY: Keep this list as specific as possible. Review whenever proxy
   # topology changes to avoid unintentionally widening the trust boundary.
+  #
+  # NOTE: This setting is REQUIRED. If not configured and disabled is false,
+  # a ConfigurationError will be raised at startup to prevent fail-open vulnerabilities.
   #
   config.trusted_proxies = ENV.fetch('TRUSTED_PROXIES', '127.0.0.1').split(',').map(&:strip)
 

--- a/lib/verikloak/bff/configuration.rb
+++ b/lib/verikloak/bff/configuration.rb
@@ -3,6 +3,8 @@
 # Configuration object for verikloak-bff. Holds middleware settings such as
 # proxy trust rules, header consistency policies, and logging options.
 #
+# @!attribute [rw] disabled
+#   @return [Boolean] explicitly disable the middleware (pass-through mode)
 # @!attribute [rw] trusted_proxies
 #   @return [Array<String, Regexp, Proc>] allowlist of trusted proxy peers
 # @!attribute [rw] prefer_forwarded
@@ -28,7 +30,7 @@ module Verikloak
   module BFF
     # Configuration for Verikloak::BFF middleware (trusted proxies, header policies, logging, etc.).
     class Configuration
-      attr_accessor :trusted_proxies, :prefer_forwarded, :require_forwarded_header,
+      attr_accessor :disabled, :trusted_proxies, :prefer_forwarded, :require_forwarded_header,
                     :enforce_header_consistency, :enforce_claims_consistency,
                     :strip_suspicious_headers, :xff_strategy, :clock_skew_leeway,
                     :logger, :peer_preference, :auth_request_headers, :log_with,
@@ -43,6 +45,7 @@ module Verikloak
       #
       # @return [void]
       def initialize
+        @disabled = false
         @trusted_proxies = []
         @prefer_forwarded = true
         @require_forwarded_header = false

--- a/lib/verikloak/bff/version.rb
+++ b/lib/verikloak/bff/version.rb
@@ -5,6 +5,6 @@
 # @return [String]
 module Verikloak
   module BFF
-    VERSION = '0.2.6'
+    VERSION = '0.3.0'
   end
 end

--- a/spec/header_guard_spec.rb
+++ b/spec/header_guard_spec.rb
@@ -122,8 +122,12 @@ RSpec.describe Verikloak::BFF::HeaderGuard do
       @app = build_app(disabled: true, trusted_proxies: nil)
       header "X-Forwarded-For", "1.2.3.4"
       header "Authorization", "Bearer test"
+      header "X-Auth-Request-Email", "user@example.com"
       get "/"
       expect(last_response.status).to eq 200
+      # Verify headers pass through unchanged in disabled mode
+      expect(last_request.env["HTTP_AUTHORIZATION"]).to eq "Bearer test"
+      expect(last_request.env["HTTP_X_AUTH_REQUEST_EMAIL"]).to eq "user@example.com"
     end
 
     it "rejects requests from untrusted proxy" do

--- a/spec/header_guard_spec.rb
+++ b/spec/header_guard_spec.rb
@@ -106,9 +106,24 @@ RSpec.describe Verikloak::BFF::HeaderGuard do
   end
 
   context "trust boundary" do
-    it "requires trusted_proxies configuration" do
-      # Ensure the middleware is instantiated (Rack::Builder lazily builds on first call)
-      expect { build_app.to_app }.to raise_error(ArgumentError)
+    it "raises ConfigurationError when trusted_proxies is not configured and disabled is false" do
+      expect {
+        build_app({}).to_app # .to_app triggers middleware initialization
+      }.to raise_error(Verikloak::BFF::HeaderGuard::ConfigurationError, /trusted_proxies must be configured/)
+    end
+
+    it "passes through when disabled: true is set explicitly" do
+      @app = build_app(disabled: true)
+      get "/"
+      expect(last_response.status).to eq 200
+    end
+
+    it "passes through when disabled: true even without trusted_proxies" do
+      @app = build_app(disabled: true, trusted_proxies: nil)
+      header "X-Forwarded-For", "1.2.3.4"
+      header "Authorization", "Bearer test"
+      get "/"
+      expect(last_response.status).to eq 200
     end
 
     it "rejects requests from untrusted proxy" do


### PR DESCRIPTION
### Added
- **`disabled` configuration option**: Explicitly disable the middleware in pass-through mode. When `disabled: false` (default) and `trusted_proxies` is not configured, a `ConfigurationError` is raised at startup.

### Changed
- **BREAKING**: `trusted_proxies` is now **required** when `disabled: false`. Previously, an empty `trusted_proxies` would silently disable the middleware (fail-open). Now it raises `Verikloak::BFF::HeaderGuard::ConfigurationError` to prevent unintended security gaps.

### Fixed
- **Security**: Prevent fail-open vulnerability where unset `trusted_proxies` could silently bypass proxy trust validation.