### PR TITLE
v1.0.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.0] - 2026-02-15
+
+### Fixed
+- **Token divergence**: `ForwardedToken.set_authorization!` now always overwrites `HTTP_AUTHORIZATION` with the chosen token. Previously, an existing Bearer header would prevent the overwrite, causing the downstream Verikloak middleware to verify a different token than the one selected by the BFF guard
+- **BREAKING**: Minimum `verikloak` dependency raised to `~> 1.0`
+
+### Added
+- **Unit tests**: Added direct unit tests for `ForwardedToken`, `JwtUtils`, and `HeaderSources` modules
+
+### Changed
+- **v1.0.0 stable release**: Public API is now considered stable under Semantic Versioning
+
+---
+
 ## [0.4.0] - 2026-02-15
 
 ### Security

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    verikloak-bff (0.4.0)
+    verikloak-bff (1.0.0)
       jwt (>= 2.7, < 4.0)
       rack (>= 2.2, < 4.0)
-      verikloak (>= 0.4.0, < 1.0.0)
+      verikloak (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -20,8 +20,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
     json (2.18.1)
@@ -30,8 +30,8 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    net-http (0.6.0)
-      uri
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     parallel (1.27.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)
@@ -90,12 +90,13 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    uri (1.0.4)
-    verikloak (0.4.0)
+    uri (1.1.1)
+    verikloak (1.0.0)
       faraday (>= 2.14.1, < 3.0)
       faraday-retry (>= 2.4.0, < 3.0)
-      json (~> 2.18)
+      json (~> 2.6)
       jwt (>= 2.7, < 4.0)
+      rack (>= 2.2, < 4.0)
 
 PLATFORMS
   aarch64-linux-musl

--- a/lib/verikloak/bff/forwarded_token.rb
+++ b/lib/verikloak/bff/forwarded_token.rb
@@ -79,16 +79,14 @@ module Verikloak
         "Bearer #{s}"
       end
 
-      # Set Authorization header to a normalized Bearer value (no overwrite when present).
+      # Set Authorization header to a normalized Bearer value.
+      # Always overwrites the existing Authorization header to ensure
+      # the chosen token and Authorization are synchronized.
       #
       # @param env [Hash]
       # @param token [String]
       # @return [void]
       def set_authorization!(env, token)
-        existing = env[AUTH_HEADER].to_s
-        # Overwrite only if Authorization is empty or not a valid Bearer value
-        return unless existing.empty? || normalize_auth(existing).nil?
-
         env[AUTH_HEADER] = ensure_bearer(token)
       end
 

--- a/lib/verikloak/bff/version.rb
+++ b/lib/verikloak/bff/version.rb
@@ -5,6 +5,6 @@
 # @return [String]
 module Verikloak
   module BFF
-    VERSION = '0.4.0'
+    VERSION = '1.0.0'
   end
 end

--- a/spec/forwarded_token_spec.rb
+++ b/spec/forwarded_token_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Verikloak::BFF::ForwardedToken do
+  let(:auth_header) { Verikloak::HeaderSources::AUTHORIZATION_HEADER }
+  let(:fwd_header)  { Verikloak::HeaderSources::DEFAULT_FORWARDED_HEADER }
+
+  describe '.extract' do
+    it 'returns [auth_token, forwarded_token] from Rack env' do
+      env = {
+        auth_header => 'Bearer auth-token-123',
+        fwd_header  => 'fwd-token-456'
+      }
+      auth, fwd = described_class.extract(env)
+      expect(auth).to eq('auth-token-123')
+      expect(fwd).to eq('fwd-token-456')
+    end
+
+    it 'returns [nil, nil] when no headers are present' do
+      auth, fwd = described_class.extract({})
+      expect(auth).to be_nil
+      expect(fwd).to be_nil
+    end
+
+    it 'strips Bearer prefix from forwarded header' do
+      env = { fwd_header => 'Bearer my-fwd-token' }
+      _, fwd = described_class.extract(env)
+      expect(fwd).to eq('my-fwd-token')
+    end
+  end
+
+  describe '.normalize_auth' do
+    it 'extracts Bearer token' do
+      expect(described_class.normalize_auth('Bearer abc123')).to eq('abc123')
+    end
+
+    it 'handles case-insensitive Bearer' do
+      expect(described_class.normalize_auth('bearer XYZ')).to eq('XYZ')
+    end
+
+    it 'handles Bearer without space' do
+      expect(described_class.normalize_auth('BearerXYZ')).to eq('XYZ')
+    end
+
+    it 'returns nil for non-Bearer schemes' do
+      expect(described_class.normalize_auth('Basic abc123')).to be_nil
+    end
+
+    it 'returns nil for nil input' do
+      expect(described_class.normalize_auth(nil)).to be_nil
+    end
+
+    it 'returns nil for empty string' do
+      expect(described_class.normalize_auth('')).to be_nil
+    end
+  end
+
+  describe '.normalize_forwarded' do
+    it 'returns bare token as-is' do
+      expect(described_class.normalize_forwarded('raw-token')).to eq('raw-token')
+    end
+
+    it 'strips Bearer prefix' do
+      expect(described_class.normalize_forwarded('Bearer raw-token')).to eq('raw-token')
+    end
+
+    it 'returns nil for nil input' do
+      expect(described_class.normalize_forwarded(nil)).to be_nil
+    end
+
+    it 'returns nil for empty string' do
+      expect(described_class.normalize_forwarded('')).to be_nil
+    end
+
+    it 'returns nil for whitespace-only input' do
+      expect(described_class.normalize_forwarded('   ')).to be_nil
+    end
+  end
+
+  describe '.ensure_bearer' do
+    it 'returns "Bearer <token>" for a bare token' do
+      expect(described_class.ensure_bearer('my-token')).to eq('Bearer my-token')
+    end
+
+    it 'normalizes existing Bearer prefix' do
+      expect(described_class.ensure_bearer('Bearer my-token')).to eq('Bearer my-token')
+    end
+
+    it 'normalizes case-insensitive Bearer' do
+      expect(described_class.ensure_bearer('bearer my-token')).to eq('Bearer my-token')
+    end
+
+    it 'inserts space when missing after Bearer' do
+      expect(described_class.ensure_bearer('BearerXYZ')).to eq('Bearer XYZ')
+    end
+
+    it 'collapses multiple spaces after Bearer' do
+      expect(described_class.ensure_bearer("Bearer   my-token")).to eq('Bearer my-token')
+    end
+  end
+
+  describe '.set_authorization!' do
+    it 'always overwrites Authorization header with normalized Bearer' do
+      env = { auth_header => 'Bearer old-token' }
+      described_class.set_authorization!(env, 'new-token')
+      expect(env[auth_header]).to eq('Bearer new-token')
+    end
+
+    it 'sets Authorization when none exists' do
+      env = {}
+      described_class.set_authorization!(env, 'my-token')
+      expect(env[auth_header]).to eq('Bearer my-token')
+    end
+  end
+
+  describe '.sanitize' do
+    it 'removes control characters' do
+      expect(described_class.sanitize("token\r\ninjection")).to eq('tokeninjection')
+    end
+
+    it 'strips leading/trailing whitespace' do
+      expect(described_class.sanitize('  token  ')).to eq('token')
+    end
+
+    it 'handles nil' do
+      expect(described_class.sanitize(nil)).to eq('')
+    end
+  end
+
+  describe '.strip_suspicious!' do
+    it 'removes default X-Auth-Request-* headers' do
+      env = {
+        'HTTP_X_AUTH_REQUEST_EMAIL'  => 'forged@evil.com',
+        'HTTP_X_AUTH_REQUEST_USER'   => 'forged-user',
+        'HTTP_X_AUTH_REQUEST_GROUPS' => 'admin',
+        'HTTP_OTHER' => 'keep-me'
+      }
+      described_class.strip_suspicious!(env)
+      expect(env).not_to have_key('HTTP_X_AUTH_REQUEST_EMAIL')
+      expect(env).not_to have_key('HTTP_X_AUTH_REQUEST_USER')
+      expect(env).not_to have_key('HTTP_X_AUTH_REQUEST_GROUPS')
+      expect(env['HTTP_OTHER']).to eq('keep-me')
+    end
+
+    it 'removes custom headers when hash is provided' do
+      env = { 'HTTP_CUSTOM' => 'val' }
+      described_class.strip_suspicious!(env, { email: 'HTTP_CUSTOM' })
+      expect(env).not_to have_key('HTTP_CUSTOM')
+    end
+  end
+end

--- a/spec/header_sources_spec.rb
+++ b/spec/header_sources_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Verikloak::HeaderSources do
+  describe '.normalize_env_key' do
+    it 'converts a plain header name to HTTP_* uppercase' do
+      expect(described_class.normalize_env_key('x-forwarded-token'))
+        .to eq('HTTP_X_FORWARDED_TOKEN')
+    end
+
+    it 'handles symbols' do
+      expect(described_class.normalize_env_key(:x_custom_header))
+        .to eq('HTTP_X_CUSTOM_HEADER')
+    end
+
+    it 'preserves existing HTTP_ prefix' do
+      expect(described_class.normalize_env_key('HTTP_AUTHORIZATION'))
+        .to eq('HTTP_AUTHORIZATION')
+    end
+
+    it 'returns empty string for nil' do
+      expect(described_class.normalize_env_key(nil)).to eq('')
+    end
+
+    it 'returns empty string for blank' do
+      expect(described_class.normalize_env_key('  ')).to eq('')
+    end
+
+    it 'strips whitespace before normalization' do
+      expect(described_class.normalize_env_key('  x-custom  '))
+        .to eq('HTTP_X_CUSTOM')
+    end
+  end
+
+  describe '.normalize_priority' do
+    it 'returns default forwarded header when priority is empty' do
+      list, fwd = described_class.normalize_priority([])
+      expect(list).to eq([Verikloak::HeaderSources::DEFAULT_FORWARDED_HEADER])
+      expect(fwd).to eq(Verikloak::HeaderSources::DEFAULT_FORWARDED_HEADER)
+    end
+
+    it 'normalizes and deduplicates entries' do
+      list, = described_class.normalize_priority(%w[x-custom x-custom x-other])
+      expect(list).to eq(['HTTP_X_CUSTOM', 'HTTP_X_OTHER'])
+    end
+
+    it 'drops Authorization by default' do
+      list, = described_class.normalize_priority(%w[Authorization x-custom])
+      expect(list).to eq(['HTTP_X_CUSTOM'])
+    end
+
+    it 'keeps Authorization when drop_authorization is false' do
+      list, = described_class.normalize_priority(%w[Authorization], drop_authorization: false)
+      expect(list).to include('HTTP_AUTHORIZATION')
+    end
+
+    it 'accepts a custom forwarded_header' do
+      list, fwd = described_class.normalize_priority([], forwarded_header: 'x-my-fwd')
+      expect(fwd).to eq('HTTP_X_MY_FWD')
+      expect(list).to eq(['HTTP_X_MY_FWD'])
+    end
+  end
+
+  describe '.default_priority' do
+    it 'returns the default forwarded header as priority' do
+      result = described_class.default_priority
+      expect(result).to eq([Verikloak::HeaderSources::DEFAULT_FORWARDED_HEADER])
+    end
+  end
+end

--- a/spec/jwt_utils_spec.rb
+++ b/spec/jwt_utils_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Verikloak::BFF::JwtUtils do
+  # A valid HS256 JWT for testing (not cryptographically meaningful — unverified decode)
+  let(:valid_jwt) do
+    payload = { 'sub' => 'user-1', 'aud' => 'test-client', 'exp' => Time.now.to_i + 600 }
+    JWT.encode(payload, 'test-secret', 'HS256')
+  end
+
+  describe '.decode_unverified' do
+    it 'decodes a valid JWT without verification' do
+      payload, header = described_class.decode_unverified(valid_jwt)
+      expect(payload['sub']).to eq('user-1')
+      expect(payload['aud']).to eq('test-client')
+      expect(header['alg']).to eq('HS256')
+    end
+
+    it 'returns [{}, {}] for nil input' do
+      payload, header = described_class.decode_unverified(nil)
+      expect(payload).to eq({})
+      expect(header).to eq({})
+    end
+
+    it 'returns [{}, {}] for oversized token' do
+      oversized = 'a' * (Verikloak::BFF::Constants::MAX_TOKEN_BYTES + 1)
+      payload, header = described_class.decode_unverified(oversized)
+      expect(payload).to eq({})
+      expect(header).to eq({})
+    end
+
+    it 'returns [{}, {}] for malformed token' do
+      payload, header = described_class.decode_unverified('not.a.jwt')
+      expect(payload).to eq({})
+      expect(header).to eq({})
+    end
+  end
+
+  describe '.decode_claims' do
+    it 'returns only the payload hash' do
+      claims = described_class.decode_claims(valid_jwt)
+      expect(claims['sub']).to eq('user-1')
+      expect(claims).not_to have_key('alg')
+    end
+
+    it 'returns {} for nil' do
+      expect(described_class.decode_claims(nil)).to eq({})
+    end
+  end
+end

--- a/verikloak-bff.gemspec
+++ b/verikloak-bff.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   # Runtime dependencies
   spec.add_dependency 'jwt', '>= 2.7', '< 4.0'
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
-  spec.add_dependency 'verikloak', '>= 0.4.0', '< 1.0.0'
+  spec.add_dependency 'verikloak', '~> 1.0'
 
   # Metadata for RubyGems
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
### Fixed
- **Token divergence**: `ForwardedToken.set_authorization!` now always overwrites `HTTP_AUTHORIZATION` with the chosen token. Previously, an existing Bearer header would prevent the overwrite, causing the downstream Verikloak middleware to verify a different token than the one selected by the BFF guard
- **BREAKING**: Minimum `verikloak` dependency raised to `~> 1.0`

### Added
- **Unit tests**: Added direct unit tests for `ForwardedToken`, `JwtUtils`, and `HeaderSources` modules

### Changed
- **v1.0.0 stable release**: Public API is now considered stable under Semantic Versioning