### PR TITLE
Release v1.1.1: CI Ruby 3.1-3.3 compatibility matrix and coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,11 @@ jobs:
         run: docker compose build --pull
 
       - name: Run RSpec with coverage and JUnit output
+        # `-e SIMPLECOV` forwards the step-level env var into the container;
+        # compose does not pass host env vars through on its own.
         run: |
           mkdir -p tmp/coverage tmp/rspec
-          docker compose run --rm -u 0:0 dev \
+          docker compose run --rm -u 0:0 -e SIMPLECOV dev \
             bash -c "bundle exec rspec --format progress --format RspecJunitFormatter --out tmp/rspec/results.xml"
         env:
           SIMPLECOV: true
@@ -65,6 +67,37 @@ jobs:
         with:
           name: rspec-coverage
           path: artifacts/
+
+  compatibility:
+    # Verifies the gemspec's `required_ruby_version >= 3.1` claim on every
+    # supported minor Ruby. The docker-based `rspec` job covers the pinned
+    # development Ruby (3.4); this matrix covers the rest without docker.
+    name: RSpec (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      BUNDLE_GEMFILE: gemfiles/compat.gemfile
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.1', '3.2', '3.3']
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run RSpec
+        run: bundle exec rspec --format progress
 
   rubocop:
     name: RuboCop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.1.1] - 2026-07-03
+
+Maintenance release. No changes to the shipped gem's runtime code — it is identical to 1.1.0. The changes below are limited to CI and the test suite (none of the affected files ship in the gem).
+
+### CI
+- Add a non-docker RSpec compatibility matrix (Ruby 3.1–3.3) via `gemfiles/compat.gemfile`, verifying the gemspec's `required_ruby_version >= 3.1` on every supported minor Ruby; the docker-based job continues to cover the pinned 3.4 development Ruby
+- Forward `SIMPLECOV` into the docker RSpec job so coverage is actually collected in CI, and enforce a 90% line-coverage floor in the suite (matching verikloak core)
+
+---
+
 ## [1.1.0] - 2026-07-03
 
 Verified against verikloak 1.1.0 (core) and verikloak-rails 1.2.0.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-bff (1.1.0)
+    verikloak-bff (1.1.1)
       jwt (>= 2.7, < 4.0)
       rack (>= 2.2, < 4.0)
       verikloak (~> 1.1)

--- a/gemfiles/compat.gemfile
+++ b/gemfiles/compat.gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Gemfile for the CI compatibility matrix (Ruby 3.1-3.4).
+# Gemfile for the CI compatibility matrix (Ruby 3.1-3.3).
 #
 # Mirrors the verikloak core setup: it carries only what the test suite needs
 # to run, so the gemspec's `required_ruby_version >= 3.1` claim stays verifiable

--- a/gemfiles/compat.gemfile
+++ b/gemfiles/compat.gemfile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Gemfile for the CI compatibility matrix (Ruby 3.1-3.4).
+#
+# Mirrors the verikloak core setup: it carries only what the test suite needs
+# to run, so the gemspec's `required_ruby_version >= 3.1` claim stays verifiable
+# on every supported minor Ruby. The docker-based `rspec` job runs the pinned
+# development Ruby (3.4.8); this matrix covers 3.1-3.3.
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+group :development, :test do
+  gem 'rspec', '~> 3.13'
+end
+
+group :test do
+  gem 'rack-test'
+end

--- a/lib/verikloak/bff/version.rb
+++ b/lib/verikloak/bff/version.rb
@@ -5,6 +5,6 @@
 # @return [String]
 module Verikloak
   module BFF
-    VERSION = '1.1.0'
+    VERSION = '1.1.1'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ if ENV['SIMPLECOV']
     SimpleCov.start do
       enable_coverage :branch
       add_filter %r{^/spec/}
+      # Match verikloak core: fail the suite when line coverage drops below 90%.
+      minimum_coverage 90
     end
   rescue LoadError
     warn '[spec_helper] simplecov not available; skipping coverage'


### PR DESCRIPTION
## Release v1.1.1

Maintenance release. **No runtime code changes versus 1.1.0** — the shipped gem differs only in `version.rb` and `CHANGELOG.md`. Everything else in this PR touches CI and the test suite, none of which ship in the gem (`spec.files` is `lib/**/*.{rb,erb}` + README/LICENSE/CHANGELOG).

## What's in this release

- **CI: Ruby 3.1–3.3 compatibility matrix** — a new non-docker `compatibility` job runs the RSpec suite on Ruby 3.1, 3.2, and 3.3 via `gemfiles/compat.gemfile`, so the gemspec's `required_ruby_version >= 3.1` claim stays verified on every supported minor. The existing docker-based `rspec` job continues to cover the pinned 3.4 development Ruby.
- **CI: SimpleCov actually runs** — `SIMPLECOV` is now forwarded into the container with `-e SIMPLECOV` on the docker `rspec` job (`docker compose` does not pass host env vars through on its own), so coverage is collected in CI instead of being silently skipped.
- **Coverage floor** — `spec/spec_helper.rb` enforces `minimum_coverage 90` (line coverage), matching verikloak core.
- **Release** — bump `lib/verikloak/bff/version.rb` to `1.1.1`, sync the `Gemfile.lock` path spec, and add the `[1.1.1]` CHANGELOG entry.

## Testing (local, docker, `SIMPLECOV=1`)

- `bundle exec rspec` → **133 examples, 0 failures**, exit 0 (SimpleCov `minimum_coverage 90` satisfied)
- `bundle exec rubocop` → **20 files inspected, no offenses**

## Post-merge (maintainer, manual)

`gem push` requires RubyGems MFA (OTP), so it cannot be automated here:

```
git tag v1.1.1 && git push --tags   # tag the merge commit on main
gem build verikloak-bff.gemspec
gem push verikloak-bff-1.1.1.gem     # prompts for OTP
```

Then create the GitHub Release for `v1.1.1` from the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
